### PR TITLE
Rebuild for cfitsio400 and apply patch 

### DIFF
--- a/.ci_support/linux_64_numpy1.18python3.7.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.18python3.7.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 cfitsio:
-- '3.470'
+- 4.0.0
 channel_sources:
 - conda-forge
 channel_targets:
@@ -36,7 +36,5 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
-- - cdt_name
-  - docker_image
 - - python
   - numpy

--- a/.ci_support/linux_64_numpy1.18python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.18python3.8.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 cfitsio:
-- '3.470'
+- 4.0.0
 channel_sources:
 - conda-forge
 channel_targets:
@@ -36,7 +36,5 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
-- - cdt_name
-  - docker_image
 - - python
   - numpy

--- a/.ci_support/linux_64_numpy1.19python3.7.____73_pypy.yaml
+++ b/.ci_support/linux_64_numpy1.19python3.7.____73_pypy.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 cfitsio:
-- '3.470'
+- 4.0.0
 channel_sources:
 - conda-forge
 channel_targets:
@@ -36,7 +36,5 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
-- - cdt_name
-  - docker_image
 - - python
   - numpy

--- a/.ci_support/linux_64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.19python3.9.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 cfitsio:
-- '3.470'
+- 4.0.0
 channel_sources:
 - conda-forge
 channel_targets:
@@ -36,7 +36,5 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
-- - cdt_name
-  - docker_image
 - - python
   - numpy

--- a/.ci_support/linux_64_numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.21python3.10.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 cfitsio:
-- '3.470'
+- 4.0.0
 channel_sources:
 - conda-forge
 channel_targets:
@@ -36,7 +36,5 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
-- - cdt_name
-  - docker_image
 - - python
   - numpy

--- a/.ci_support/linux_aarch64_numpy1.18python3.7.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.18python3.7.____cpython.yaml
@@ -9,7 +9,7 @@ cdt_arch:
 cdt_name:
 - cos7
 cfitsio:
-- '3.470'
+- 4.0.0
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_aarch64_numpy1.18python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.18python3.8.____cpython.yaml
@@ -9,7 +9,7 @@ cdt_arch:
 cdt_name:
 - cos7
 cfitsio:
-- '3.470'
+- 4.0.0
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_aarch64_numpy1.19python3.7.____73_pypy.yaml
+++ b/.ci_support/linux_aarch64_numpy1.19python3.7.____73_pypy.yaml
@@ -9,7 +9,7 @@ cdt_arch:
 cdt_name:
 - cos7
 cfitsio:
-- '3.470'
+- 4.0.0
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_aarch64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.19python3.9.____cpython.yaml
@@ -9,7 +9,7 @@ cdt_arch:
 cdt_name:
 - cos7
 cfitsio:
-- '3.470'
+- 4.0.0
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_aarch64_numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.21python3.10.____cpython.yaml
@@ -9,7 +9,7 @@ cdt_arch:
 cdt_name:
 - cos7
 cfitsio:
-- '3.470'
+- 4.0.0
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_ppc64le_numpy1.18python3.7.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.18python3.7.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos7
 cfitsio:
-- '3.470'
+- 4.0.0
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_ppc64le_numpy1.18python3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.18python3.8.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos7
 cfitsio:
-- '3.470'
+- 4.0.0
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_ppc64le_numpy1.19python3.7.____73_pypy.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.19python3.7.____73_pypy.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos7
 cfitsio:
-- '3.470'
+- 4.0.0
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_ppc64le_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.19python3.9.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos7
 cfitsio:
-- '3.470'
+- 4.0.0
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_ppc64le_numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.21python3.10.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos7
 cfitsio:
-- '3.470'
+- 4.0.0
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/migrations/cfitsio400.yaml
+++ b/.ci_support/migrations/cfitsio400.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+cfitsio:
+- 4.0.0
+migrator_ts: 1634579492.5120957

--- a/.ci_support/osx_64_numpy1.18python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.18python3.7.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 cfitsio:
-- '3.470'
+- 4.0.0
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_64_numpy1.18python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.18python3.8.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 cfitsio:
-- '3.470'
+- 4.0.0
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_64_numpy1.19python3.7.____73_pypy.yaml
+++ b/.ci_support/osx_64_numpy1.19python3.7.____73_pypy.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 cfitsio:
-- '3.470'
+- 4.0.0
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.19python3.9.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 cfitsio:
-- '3.470'
+- 4.0.0
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_64_numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.21python3.10.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 cfitsio:
-- '3.470'
+- 4.0.0
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_arm64_numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.19python3.8.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 cfitsio:
-- '3.470'
+- 4.0.0
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_arm64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.19python3.9.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 cfitsio:
-- '3.470'
+- 4.0.0
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_arm64_numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.21python3.10.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 cfitsio:
-- '3.470'
+- 4.0.0
 channel_sources:
 - conda-forge
 channel_targets:

--- a/recipe/340d9f72c-cfitsio-4-0-0-version-support.patch
+++ b/recipe/340d9f72c-cfitsio-4-0-0-version-support.patch
@@ -1,0 +1,28 @@
+--- healpixsubmodule/src/cxx/cxxsupport/fitshandle.cc.orig	2021-12-02 08:05:04.000000000 -0800
++++ healpixsubmodule/src/cxx/cxxsupport/fitshandle.cc	2021-12-02 08:08:32.000000000 -0800
+@@ -801,10 +801,25 @@
+         "error calling fits_get_version()");
+       int v_header  = nearest<int>(1000.*CFITSIO_VERSION),
+           v_library = nearest<int>(1000.*fitsversion);
++      /* CFITSIO 4.x switched to a three version format (4.0.0), as opposed
++       * to previous two-number versions (3.47). Version 4 defines a new macro
++       * CFITSIO_MICRO to track the patch level in the version. We check if
++       * macro is defined, and fall back to the old behaviour if it is not.
++       * If it is, we adapt to the new value returned by 'fits_get_version'.
++       */
++#ifdef CFITSIO_MICRO
++      int v_header  = nearest<int>(1E6*CFITSIO_MAJOR + 1000.*CFITSIO_MINOR + CFITSIO_MICRO),
++          v_library = nearest<int>(1E6*fitsversion);
++      if (v_header!=v_library)
++        cerr << endl << "WARNING: version mismatch between CFITSIO header (v"
++             << dataToString(v_header*1.0E-6) << ") and linked library (v"
++             << dataToString(v_library*1.0E-6) << ")." << endl << endl;
++#else
+       if (v_header!=v_library)
+         cerr << endl << "WARNING: version mismatch between CFITSIO header (v"
+              << dataToString(v_header*0.001) << ") and linked library (v"
+              << dataToString(v_library*0.001) << ")." << endl << endl;
++#endif
+       }
+   };
+ 

--- a/recipe/340d9f72c-cfitsio-4-0-0-version-support.patch
+++ b/recipe/340d9f72c-cfitsio-4-0-0-version-support.patch
@@ -1,9 +1,9 @@
 --- healpixsubmodule/src/cxx/cxxsupport/fitshandle.cc.orig	2021-12-02 08:05:04.000000000 -0800
-+++ healpixsubmodule/src/cxx/cxxsupport/fitshandle.cc	2021-12-02 08:08:32.000000000 -0800
-@@ -801,10 +801,25 @@
++++ healpixsubmodule/src/cxx/cxxsupport/fitshandle.cc	2021-12-02 08:23:44.000000000 -0800
+@@ -799,12 +799,27 @@
+       float fitsversion;
+       planck_assert(fits_get_version(&fitsversion),
          "error calling fits_get_version()");
-       int v_header  = nearest<int>(1000.*CFITSIO_VERSION),
-           v_library = nearest<int>(1000.*fitsversion);
 +      /* CFITSIO 4.x switched to a three version format (4.0.0), as opposed
 +       * to previous two-number versions (3.47). Version 4 defines a new macro
 +       * CFITSIO_MICRO to track the patch level in the version. We check if
@@ -18,6 +18,8 @@
 +             << dataToString(v_header*1.0E-6) << ") and linked library (v"
 +             << dataToString(v_library*1.0E-6) << ")." << endl << endl;
 +#else
+       int v_header  = nearest<int>(1000.*CFITSIO_VERSION),
+           v_library = nearest<int>(1000.*fitsversion);
        if (v_header!=v_library)
          cerr << endl << "WARNING: version mismatch between CFITSIO header (v"
               << dataToString(v_header*0.001) << ") and linked library (v"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - cross-rpath-flag-workaround.patch  # [aarch64]
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
   patches:
     - macos-c++-linking.patch    # [osx]
     - cross-rpath-flag-workaround.patch  # [aarch64]
+    - 340d9f72c-cfitsio-4-0-0-version-support.patch
 
 build:
   number: 2


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

This PR fixes the migration from #43 by applying the healpix patch to support the new cfitsio versioning scheme (specifically https://github.com/healpy/healpixmirror/commit/340d9f72c1adefea3ffd5ea55bb62fbe686c79d9 and https://github.com/healpy/healpixmirror/commit/b070d8ad1e1561f79784388b87194ef0c1572afa ).

These patches will no longer be necessary when the next version of healpy is released, but in the meantime this can allow the conda forge migration to cfitsio400 to continue.

<!--
Please add any other relevant info below:
-->
