### PR TITLE
Unpin scipy for 1.17.3

### DIFF
--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -43,6 +43,12 @@ setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 source run_conda_forge_build_setup
 
+(
+# Due to https://bugzilla.redhat.com/show_bug.cgi?id=1537564 old versions of rpm
+# are drastically slowed down when the number of file descriptors is very high.
+# This can be visible during a `yum install` step of a feedstock build.
+# => Set a lower limit in a subshell for the `yum install`s only.
+ulimit -n 1024
 
 # Install the yum requirements defined canonically in the
 # "recipe/yum_requirements.txt" file. After updating that file,
@@ -51,7 +57,8 @@ source run_conda_forge_build_setup
 /usr/bin/sudo -n yum install -y xorg-x11-server-Xorg
 
 
-# make the build number clobber
+
+)# make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]] && [[ "${HOST_PLATFORM}" != linux-* ]] && [[ "${BUILD_WITH_CONDA_DEBUG:-0}" != 1 ]]; then
@@ -80,7 +87,6 @@ else
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
         --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
-
     ( startgroup "Inspecting artifacts" ) 2> /dev/null
 
     # inspect_artifacts was only added in conda-forge-ci-setup 4.6.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - cross-rpath-flag-workaround.patch  # [aarch64]
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win or py<39]
 
 requirements:
@@ -45,7 +45,7 @@ requirements:
     - python
     - matplotlib-base
     - astropy
-    - scipy <1.14.0
+    - scipy
 
 test:
   source_files:


### PR DESCRIPTION
healpy 1.17.2 fixed the compatibility with scipy 1.14, but the max pin wasn't removed. This PR updates that.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
